### PR TITLE
WD-862 Fix lists in bbcode notes

### DIFF
--- a/assets/javascripts/discourse-markdown/notifications.js.es6
+++ b/assets/javascripts/discourse-markdown/notifications.js.es6
@@ -3,13 +3,13 @@ export function setup(helper) {
     return;
   }
 
-  helper.whiteList([
+  helper.allowList([
     'div.p-notification',
     'div.p-notification--caution',
     'div.p-notification--positive',
     'div.p-notification--negative',
     'div.p-notification--important',
-    'p.p-notification__response',
+    'div.p-notification__response',
     'span.p-notification__status'
   ]);
 
@@ -32,8 +32,7 @@ export function setup(helper) {
         // Start wrapper elements:
         // <div class="p-notification"><p class="p-notification__render">
         state.push('div_open', 'div', 1).attrSet('class', notificationClass);
-        state.push('paragraph_open', 'p', 1).attrSet('class', 'p-notification__response');
-
+        state.push('div_open', 'div', 1).attrSet('class', 'p-notification__response');
         // Add status:
         // <span class="p-notification__status">{status}</span>
         if ('status' in tagInfo.attrs) {
@@ -42,17 +41,27 @@ export function setup(helper) {
           state.push('span_close', 'span', -1);
         }
 
-        // Add the [note] content inline
-        let token = state.push('inline', '', 0);
-        token.content = content;
-        token.children = [];
-
+        // Add the [note] content
+        const tokens = state.md.parse(content);
+        tokens.forEach(element => {
+          // For some reason, "inline" elements contain their text twice,
+          // which duplicates the text on the page.
+          // This is because the text appears both inside the "content" of the inline block,
+          // and in a "text" child node of the block.
+          // We therefore strip the "content", so the text only appears once.
+          if (element.type == "inline") {
+            element.content = ""
+          }
+          state.tokens.push(element)
+        });
+        
         // Close the wrapper elements
-        state.push('paragraph_close', 'p', -1);
+        state.push('div_close', 'div', -1);
         state.push('div_close', 'div', -1);
 
         return true;
       }
     });
+    
   });
 }

--- a/assets/stylesheets/notifications.scss
+++ b/assets/stylesheets/notifications.scss
@@ -1,6 +1,7 @@
 .p-notification__response {
   padding: 0.5rem;
   border: 1px solid #666;
+  margin-bottom: 1.5rem;
 }
 
 .p-notification--caution .p-notification__response {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "discourse-markdown-note",
-  "version": "1.0.0",
+  "version": "0.0.2",
   "scripts": {
     "lint": "prettier --write **/*.{es6,scss}"
   },

--- a/plugin.rb
+++ b/plugin.rb
@@ -1,6 +1,6 @@
 # name: markdown-note
 # about: A BBCode Markdown extension for notes
-# version: 0.0.1
+# version: 0.0.2
 # authors: Robin Winslow
 
 register_asset "stylesheets/notifications.scss"


### PR DESCRIPTION
## Done

Fix lists in bb code notes.

Before:
![image](https://user-images.githubusercontent.com/14939793/207637595-89c69307-5ece-4cad-90f0-b3e07895856a.png)


After:
![image](https://user-images.githubusercontent.com/14939793/207637899-2203df32-5eaa-468c-97c6-1433205ebed6.png)


## QA

Clone discourse repo:
```
git clone https://github.com/discourse/discourse.git
cd discourse
```
Get the plugin
```
# change directory inside the plugin folder
cd plugins
git clone https://github.com/canonical/discourse-markdown-note.git
git fetch origin
git checkout fix-note-lists
```

Launch Discourse locally:
```
# go to the root directory of the discourse folder
cd ..
d/boot_dev --init
    # wait while:
    #   - dependencies are installed,
    #   - the database is migrated, and
    #   - an admin user is created (you'll need to interact with this)
```

```
# In one terminal:
d/rails s

# And in a separate terminal
d/ember-cli
Go to http://localhost:4200/. Discourse should be running.
```

One discourse is running, create a new topic with this content: https://pastebin.canonical.com/p/cKr8gmGF7q/. Check that Markdown inside notes are displaying correctly now


## Issue

Closes https://warthogs.atlassian.net/browse/WD-862?atlOrigin=eyJpIjoiOTU5NjZlMGNmNzc2NGM3Nzg1NDE4ZmM1MDE1YjM3NjIiLCJwIjoiaiJ9
Closes https://github.com/canonical/discourse-markdown-note/issues/16